### PR TITLE
Report active status when the charm is ready

### DIFF
--- a/reactive/kubeflow_tf_job_dashboard.py
+++ b/reactive/kubeflow_tf_job_dashboard.py
@@ -4,6 +4,11 @@ from charms.reactive import when, when_not
 from charms import layer
 
 
+@when('charm.kubeflow-tf-job-dashboard.started')
+def charm_ready():
+    layer.status.active('')
+
+
 @when('layer.docker-resource.tf-operator-image.changed')
 def update_image():
     clear_flag('charm.kubeflow-tf-job-dashboard.started')


### PR DESCRIPTION
When charm has pushed the pod spec, report status as active so juju can correctly reflect the unit status when the container has started.