### PR TITLE
Adding upstream source for oci-image resource

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -17,3 +17,4 @@ resources:
     type: oci-image
     description: 'Image for tf-operator'
     auto-fetch: true
+    upstream-source: 'gcr.io/kubeflow-images-public/tf_operator:v0.4.0'


### PR DESCRIPTION
So that the charm building job knows which image to use